### PR TITLE
fix handling mobileconfig for mdm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A structured fact is also provided to list installed profiles along with some me
 
 ## Usage
 
+> Local profile installation is non-functional on macOS 11 and newer. Use the method => 'mdm' below.
+
 <pre>
 mac_profiles_handler::manage { 'com.puppetlabs.myprofile':
   ensure  => present,
@@ -39,7 +41,7 @@ You must pass the profilers identifier as your namevar, ensure accepts present o
 
 ### Profile installation via MicroMDM and MDMDirector
 
-Profiles can be sent via MDMDirector and compatible tools. Add your configuration to Hiera (`eyaml` recommended for secrets). Only template style profiles are supported.
+Profiles can be sent via MDMDirector and compatible tools. Add your configuration to Hiera (`eyaml` recommended for secrets).
 
 <pre>
 # MDMDirector information
@@ -50,14 +52,34 @@ mac_profiles_handler::mdmdirector_username: mdmdirector
 mac_profiles_handler::method: mdm
 </pre>
 
-Or you can install only some profiles via MDM
+
+You can install profiles with a mobileconfig file in the module or an ERB template.
+
+<pre>
+mac_profiles_handler::manage { 'com.puppetlabs.myprofile':
+  ensure  => present,
+  file_source => 'puppet:///modules/mymodule/com.puppetlabs.myprofile.mobileconfig',
+  method => 'mdm'
+}
+</pre>
 
 <pre>
 mac_profiles_handler::manage { 'com.puppetlabs.myprofile':
   ensure  => present,
   file_source => template('mymodule/com.puppetlabs.myprofile.erb'),
   type => 'template',
-  method => 'mdm' # or set this to 'local'
+  method => 'mdm'
+}
+</pre>
+
+When ensuring a profile is removed, you must also provide the file_source and method.
+
+<pre>
+mac_profiles_handler::manage { 'com.puppetlabs.myprofile':
+  ensure  => absent,
+  file_source => template('mymodule/com.puppetlabs.myprofile.erb'),
+  type => 'template',
+  method => 'mdm'
 }
 </pre>
 

--- a/manifests/mdm.pp
+++ b/manifests/mdm.pp
@@ -9,15 +9,10 @@ define mac_profiles_handler::mdm (
 
   $enrolled = $facts['mdmenrollment']['mdm_enrolled']
 
-  if $type != 'template' {
-    if 'puppet:///modules/' in $file_source {
-      $munged_source = inline_template('<%= @file_source[18..-1] %>')
-      notify{$munged_source: }
-      $input = file($munged_source)
-    }
-    else {
-      $input = $file_source
-    }
+  if 'puppet:///modules/' in $file_source {
+    $munged_source = inline_template('<%= @file_source[18..-1] %>')
+    notify{$munged_source: }
+    $input = file($munged_source)
   } else {
     $input = $file_source
   }
@@ -28,7 +23,7 @@ define mac_profiles_handler::mdm (
     }
   }
 
-  if $enrolled and $type == 'template' {
+  if $enrolled {
 
     $profiles = $facts['profiles']
 


### PR DESCRIPTION
Adds support for handling mobileconfig files for `type => 'mdm'`

The [logic for reading the mobilconfig](https://github.com/macadmins/puppet-mac_profiles_handler/compare/master...vdesouza:fix_handling_mobileconfig?expand=1#diff-f758cf74d1eda54484fc944ddc88872de232576801385b870dcdecf659f57589L12) was already there. But the conditional logic of requiring `$type == 'template'` for all mdm profiles led to all mobileconfig files to be [ignored](https://github.com/macadmins/puppet-mac_profiles_handler/compare/master...vdesouza:fix_handling_mobileconfig?expand=1#diff-f758cf74d1eda54484fc944ddc88872de232576801385b870dcdecf659f57589L31).

Also update the readme 
- to reflect this change 
- document the required `file_source` for removing profiles with mdm
- adding note about local profile installation not working after macOS 11